### PR TITLE
chore: Upgrade to chalk@5 and natural@8

### DIFF
--- a/lib/calcRelatedPosts.js
+++ b/lib/calcRelatedPosts.js
@@ -1,4 +1,7 @@
-const { magenta, blue } = require('chalk');
+let magenta, blue;
+import('chalk').then(({ default: chalk }) => {
+    ({ magenta, blue } = chalk);
+});
 const prepareReservedWords = require('./text/prepareReservedWords');
 const generateWordVectors = require('./tfidf/generateWordVectors');
 const calculateTfs = require('./tfidf/calculateTfs');

--- a/package.json
+++ b/package.json
@@ -26,13 +26,10 @@
   },
   "homepage": "https://github.com/sergeyzwezdin/hexo-related-posts#readme",
   "peerDependencies": {
-    "hexo": "^4.2.0 || ^5.2.0 || ^6.3.0 || ^7.1.1",
-    "chalk": "^4.1.0"
+    "hexo": "^4.2.0 || ^5.2.0 || ^6.3.0 || ^7.1.1"
   },
   "dependencies": {
-    "natural": "^2.1.5"
-  },
-  "devDependencies": {
-    "chalk": "^4.1.0"
+    "chalk": "^5.3.0",
+    "natural": "^8.0.1"
   }
 }


### PR DESCRIPTION
- Bumps to `chalk 5` and `natural 8`
- `chalk` switched to ESM since v5, now dynamically importing it in `calcRelatedPosts.js`.
- Removed `chalk` from dev

See #23 